### PR TITLE
feat(footer): add email subscription link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ guardian:
     twitter: <TWITTER_USERNAME>
     github_org: <GITHUB_ORGANIZATION_NAME>
     github_repo: <GITHUB_REPOSITORY_NAME>
+    email_subscription_url: <EMAIL_SUBSCRIPTION_URL>
   tracking:
     google_analytics_code: <GOOGLE_ANANLYTICS_CODE>
     disqus_shortname: <DISQUS_SHORTNAME>

--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ guardian:
     twitter: widendev
     github_org: widen
     github_repo: jekyll-theme-guardian
+    email_subscription_url: https://widen.com
   tracking:
     google_analytics_code:
     disqus_shortname:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,6 +15,9 @@
         <nav>
           <ul class="site-social-links inline">
               <li><a target="_blank" title="RSS Feed" href="/feed.xml" class="ion-social-rss"></a></li>
+              {% if site.guardian.social_links.email_subscription_url %}
+              <li><a target="_blank" title="Email Subscription" href="{{ site.guardian.social_links.email_subscription_url }}" class="ion-email-unread"></a></li>
+              {% endif %}
               <li><a target="_blank" title="GitHub" href="https://github.com/{{ site.guardian.social_links.github_org }}" class="ion-social-github"></a></li>
               <li><a target="_blank" title="Twitter" href="https://twitter.com/{{ site.guardian.social_links.twitter }}" class="ion-social-twitter"></a></li>
           </ul>


### PR DESCRIPTION
For the Developer Blog, we wanted to give users another easy way to subscribe to content. We ended up linking our RSS feed to FeedBurner, which offers native email publishing based on feed content. The configured link can then point to something like this: https://feedburner.google.com/fb/a/mailverify?uri=WidenDeveloper

<img width="833" alt="Screen Shot 2020-07-30 at 1 19 26 PM" src="https://user-images.githubusercontent.com/683086/88959644-f0b3c880-d267-11ea-8c85-3b87f183da52.png">

Down the road we could also implement an actual HTML form and allow subscribing directly within the blog, but this seemed like a wicked easy first pass. Once this gets merged, implementing apps of this theme just need to provide one new configuration option in their `_config.yml`.

@forsethc brought up the fact that the version of Ionicon in this theme are really old and the email icon looks kind of bad (we did see that the newer version of Ionicons looks much better: https://ionicons.com/ (current version is v5+). Perhaps we should think of upgrading soon too?