### PR TITLE
chore(deps): update jekyll version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@
 
 source "https://rubygems.org"
 gemspec
+
+gem "jekyll", "3.9.0"
+gem "kramdown-parser-gfm", "1.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     jekyll-theme-guardian (0.0.1)
-      jekyll (~> 3.8.7)
+      jekyll (~> 3.9.0)
 
 GEM
   remote: https://rubygems.org/
@@ -10,7 +10,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -20,14 +20,14 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.7)
+    jekyll (3.9.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
       i18n (~> 0.7)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 1.14)
+      kramdown (>= 1.17, < 3)
       liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)
@@ -37,7 +37,10 @@ GEM
       sass (~> 3.4)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (1.17.0)
+    kramdown (2.3.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     liquid (4.0.3)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -45,12 +48,13 @@ GEM
     mercenary (0.3.6)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (3.1.1)
+    public_suffix (4.0.5)
     rake (12.3.3)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rouge (3.19.0)
+    rexml (3.2.4)
+    rouge (3.22.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -63,7 +67,9 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  jekyll (= 3.9.0)
   jekyll-theme-guardian!
+  kramdown-parser-gfm (= 1.1.0)
   rake (~> 12.0)
 
 BUNDLED WITH

--- a/jekyll-theme-guardian.gemspec
+++ b/jekyll-theme-guardian.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(_config.yml|assets|_layouts|_includes|_sass|LICENSE|README)!i) }
 
-  spec.add_runtime_dependency "jekyll", "~> 3.8.7"
+  spec.add_runtime_dependency "jekyll", "~> 3.9.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
This aligns the jekyll version with that exposed in [github pages dependencies](https://pages.github.com/versions/). It also ensure that our kramdown dependency is updated to 2.3.0 which [addresses a security concern](https://github.com/Widen/jekyll-theme-guardian/network/alert/Gemfile.lock/kramdown/open).