### PR TITLE
fix(git): add config for displaying git info

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,10 @@ guardian:
   style:
     logo_url: <URL>
     header_background_url: <URL>
-    git_info_enabled: <BOOLEAN>
   social_links:
     twitter: <TWITTER_USERNAME>
     github_org: <GITHUB_ORGANIZATION_NAME>
-    github_repo: <GITHUB_REPOSITORY_NAME>
+    github_repo: <GITHUB_REPOSITORY_NAME> (if present, GitHub links will be rendered in the footer)
     email_subscription_url: <EMAIL_SUBSCRIPTION_URL>
   tracking:
     google_analytics_code: <GOOGLE_ANANLYTICS_CODE>
@@ -56,7 +55,7 @@ guardian:
   * `analytics` - if `site.guardian.tracking.google_analytics_code` is populated, this will include GA tracking code
 * `header` - included on the `default` layout; renders the header with `site.guardian.style.logo_url` and `site.guardian.style.header_background_url`
 * `footer` - included on the `default` layout; renders a footer with social links
-  * `git-info` - includes links to GitHub to view/edit content
+  * `git-info` - includes links to GitHub to view/edit content (if `site.guardian.social_links.github_repo` is present)
 * `disqus` - included on the `post` layout; if `site.guardian.tracking.disqus_shortname` is populated, this will include a Disqus comment block
 
 ### Assets

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ guardian:
   style:
     logo_url: <URL>
     header_background_url: <URL>
+    git_info_enabled: <BOOLEAN>
   social_links:
     twitter: <TWITTER_USERNAME>
     github_org: <GITHUB_ORGANIZATION_NAME>

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,6 @@ guardian:
   style:
     logo_url: https://embed.widencdn.net/img/widen/c17yrvuaac/400px@2x/Widen Engineering White Logo.png?u=mcuc7i
     header_background_url: https://embed.widencdn.net/img/widen/m4ml1kuspv/exact/1680x90_Engineering Blog Banner.png?keep=c&crop=yes&u=ksmgip
-    git_info_enabled: true
   social_links:
     twitter: widendev
     github_org: widen

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ guardian:
   style:
     logo_url: https://embed.widencdn.net/img/widen/c17yrvuaac/400px@2x/Widen Engineering White Logo.png?u=mcuc7i
     header_background_url: https://embed.widencdn.net/img/widen/m4ml1kuspv/exact/1680x90_Engineering Blog Banner.png?keep=c&crop=yes&u=ksmgip
+    git_info_enabled: true
   social_links:
     twitter: widendev
     github_org: widen

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,15 +14,13 @@
         </nav >
         <nav>
           <ul class="site-social-links inline">
-              <li><a target="_blank" title="RSS Feed" href="{{ "/feed.xml" | relative_url }}"><ion-icon name="logo-rss"></ion-icon></a></li>          
+              <li><a target="_blank" title="RSS Feed" href="{{ "/feed.xml" | relative_url }}"><ion-icon name="logo-rss"></ion-icon></a></li>
               <li><a target="_blank" title="GitHub" href="https://github.com/{{ site.guardian.social_links.github_org }}"><ion-icon name="logo-github"></ion-icon></a></li>
               <li><a target="_blank" title="Twitter" href="https://twitter.com/{{ site.guardian.social_links.twitter }}"><ion-icon name="logo-twitter"></ion-icon></a></li>
           </ul>
         </nav>
         <p>© Copyright {{ site.time | date: '%Y' }}, <a title="Widen Homepage" target="_blank" href="http://widen.com">Widen Enterprises, Inc.</a></p>
-
         <p><strong>Looking for work?</strong> <a title="Come engineer with us!" target="_blank" href="http://www.widen.com/careers/">Come engineer with us!</a></p>
-        <p><strong>Something wrong with this page?</strong> Please <a title="Create new issue on bugtracker" target="_blank" href="https://github.com/{{ site.guardian.social_links.github_org }}/{{ site.guardian.social_links.github_repo }}/issues/new">file a bug</a>.</p>
         {% include git-info.html %}
     </footer>
 </div>

--- a/_includes/git-info.html
+++ b/_includes/git-info.html
@@ -1,4 +1,4 @@
-{% if site.guardian.style.git_info_enabled %}
+{% if site.guardian.social_links.github_repo %}
 <p><strong>Something wrong with this page?</strong> Please <a title="Create new issue on bugtracker" target="_blank" href="https://github.com/{{ site.guardian.social_links.github_org }}/{{ site.guardian.social_links.github_repo }}/issues/new">file a bug</a>.</p>
 <div class="git-info">
 <nav>

--- a/_includes/git-info.html
+++ b/_includes/git-info.html
@@ -1,3 +1,5 @@
+{% if site.guardian.style.git_info_enabled %}
+<p><strong>Something wrong with this page?</strong> Please <a title="Create new issue on bugtracker" target="_blank" href="https://github.com/{{ site.guardian.social_links.github_org }}/{{ site.guardian.social_links.github_repo }}/issues/new">file a bug</a>.</p>
 <div class="git-info">
 <nav>
   <ul class="inline">
@@ -19,3 +21,4 @@
   </ul>
   </nav >
 </div>
+{% endif %}


### PR DESCRIPTION
This config now allows the git info links to be hidden if desired (as well as moves the bug filing link into the git-info partial template to also be hidden, since it references the git repo).

Note: The organization github link is still exposed and visible.